### PR TITLE
Fix debridav and minor fix stremthru

### DIFF
--- a/apps/debridav/compose.yaml
+++ b/apps/debridav/compose.yaml
@@ -54,9 +54,9 @@ services:
       - debridav
       - all
 
-  debridav_rclone:
+  rclone:
     image: rclone/rclone:latest
-    container_name: debridav_rclone
+    container_name: rclone
     restart: unless-stopped
     environment:
       - TZ=${TZ}

--- a/apps/stremthru/.env
+++ b/apps/stremthru/.env
@@ -131,7 +131,7 @@ STREMTHRU_INTEGRATION_TRAKT_CLIENT_SECRET=
 #    DATABASE CONFIGURATION
 # ================================
 STREMTHRU_DATABASE_URI=sqlite://./data/stremthru.db
-STREMTHRU_REDIS_URI=redis://stremthru_redis:6379
+# STREMTHRU_REDIS_URI=redis://stremthru_redis:6379
 
 
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -12,7 +12,6 @@ include:
   - apps/cloudflare-ddns/compose.yaml
   - apps/comet/compose.yaml
   - apps/dash/compose.yaml
-  - apps/debridav/compose.yaml
   - apps/decypharr/compose.yaml
   - apps/dockge/compose.yaml
   - apps/dozzle/compose.yaml
@@ -72,7 +71,8 @@ include:
   # To use both, update Zurg's rclone service name and its container name to rclone_zurg
   # You will also need to change Zurg's rclone's `- apps//mnt/remote/realdebrid:/data:rshared` to `- apps//mnt/remote/zurg:/data:rshared`
   # - apps/zurg/compose.yaml
-
+  # same as above for using debridav, Uncomment debridav and comment out decypharr and zurg
+  # - apps/debridav/compose.yaml
 networks:
   default:
     name: ${DOCKER_NETWORK:-aio_default}

--- a/data/debridav/rclone.conf
+++ b/data/debridav/rclone.conf
@@ -1,5 +1,5 @@
 [debridav]
 type = webdav
-url = http://debridav:8080/webdav/premiumize
+url = http://debridav:8080/
 vendor = other
 pacer_min_sleep = 0


### PR DESCRIPTION
Since rclone is used by Decypharr, Debridav, and Zurg, there were conflicts due to the lack of a dedicated rclone configuration for Debridav in the *Arr stack. To resolve this, I followed the same approach used for Zurg and updated the setup to ensure Debridav works properly without conflicts.

also minor fix in .env of stremthru as redis was removed already last time